### PR TITLE
General cleanup of WebDriver.

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -231,6 +231,9 @@ class Select implements WebElement {
   WebElement get firstSelectedOption =>
       options.firstWhere((option) => option.selected);
 
+  /// String representation of the current value of this select.
+  String get value => _element.attributes['value'];
+
   /**
    * Select the option at the given [index].
    * This is done by examing the "index" attribute of an element, and not

--- a/lib/src/web_element.dart
+++ b/lib/src/web_element.dart
@@ -72,9 +72,6 @@ class WebElement extends _WebDriverBase with SearchContext {
   /// Visible text within this element.
   String get text => _get('text');
 
-  /// The value for this element
-  String get value => _get('value');
-
   /**
    * Access to the HTML attributes of this tag.
    *

--- a/lib/sync_webdriver.dart
+++ b/lib/sync_webdriver.dart
@@ -23,8 +23,8 @@ import 'dart:mirrors';
 
 import 'package:collection/wrappers.dart';
 import 'package:crypto/crypto.dart';
+import 'package:matcher/matcher.dart';
 import 'package:sync_socket/sync_socket.dart';
-import 'package:unittest/matcher.dart';
 
 part 'src/alert.dart';
 part 'src/capabilities.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,16 @@
 name: sync_webdriver
 author: Marc Fisher II
-version: 0.0.8
+version: 1.0.0
 description: Provides WebDriver bindings for Dart. These use the WebDriver JSON interface, and as such, require the use of the WebDriver remote server.
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.5.3 <2.0.0'
 dependencies:
-  collection: '>=0.9.0 <0.10.0'
+  collection: '>=0.9.4 <0.10.0'
   crypto: '>=0.9.0 <0.10.0'
+  matcher: '>=0.11.1 <0.12.0'
   sync_socket:
     path: ../dart-sync-socket
 dev_dependencies:
-  path: '>=1.0.0 <2.0.0'
-  unittest: '>=0.9.0 <0.10.0'
+  path: '>=1.2.2 <2.0.0'
+  unittest: '>=0.11.0+3 <0.12.0'
+

--- a/test/src/navigation_test.dart
+++ b/test/src/navigation_test.dart
@@ -16,6 +16,8 @@ limitations under the License.
 
 library webdriver_test.navigation;
 
+import 'dart:io';
+
 import 'package:unittest/unittest.dart';
 import 'package:sync_webdriver/sync_webdriver.dart';
 import '../test_util.dart';
@@ -42,6 +44,7 @@ void main() {
     test('refresh', () {
       var element = driver.findElement(new By.name('q'));
       driver.navigate.refresh();
+      sleep(new Duration(seconds: 1));
       expect(() => element.name,
           throwsA(new isInstanceOf<StaleElementReferenceException>()));
     });

--- a/test/src/util_test.dart
+++ b/test/src/util_test.dart
@@ -22,74 +22,80 @@ import '../test_util.dart';
 
 void main() {
 
-  WebDriver driver;
-
-  setUp(() {
-    driver = freshDriver;
-    driver.url = testPagePath;
-  });
-
   group('waitFor()', () {
-
     test('that returns a string', () {
-      driver.url = 'http://www.google.com/ncr';
-      driver.findElement(new By.name('q'))
-        .sendKeys('webdriver');
-      driver.findElement(new By.name('btnG')).click();
-      var title =
-          waitFor(() => driver.title, equals('webdriver - Google Search'));
-      expect(title, equals('webdriver - Google Search'));
+      var count = 0;
+      var result = waitFor(
+          () {
+            if (count == 2) return 'webdriver - Google Search';
+            count++;
+            return count;
+          },
+          equals('webdriver - Google Search'));
+
+      expect(result, equals('webdriver - Google Search'));
     });
 
     test('that returns null', () {
-      driver.url = 'http://www.google.com/ncr';
-      var result = waitFor(() => null, isNull);
+      var count = 0;
+      var result = waitFor(
+          () {
+            if (count == 2) return null;
+            count++;
+            return count;
+          },
+          isNull);
       expect(result, isNull);
     });
 
     test('that returns false', () {
-      driver.url = 'http://www.google.com/ncr';
-      driver.findElement(new By.name('q'))
-        .sendKeys('webdriver');
-      driver.findElement(new By.name('btnG')).click();
+      var count = 0;
       var result = waitFor(
-          () => driver.findElement(const By.name('btnI')).displayed, isFalse);
+          () {
+            if (count == 2) return false;
+            count++;
+            return count;
+          },
+          isFalse);
       expect(result, isFalse);
     });
   });
 
   group('waitForValue()', () {
-
     test('that returns a string', () {
-      driver.url = 'http://www.google.com/ncr';
-      var title = waitForValue(() => driver.title);
-      expect(title, equals('Google'));
-    });
-
-    test('that returns temporarily returns null', () {
-      const NOT_NULL = 'not-null';
-      int called = 0;
-      nullUntilSecondInvocation() {
-        if (called > 0) {
-          return NOT_NULL;
-        }
-        ++called;
-        return null;
-      }
-
-      var result = waitForValue(() => nullUntilSecondInvocation());
-      expect(result, NOT_NULL);
+      var count = 0;
+      var result = waitForValue(
+          () {
+            if (count == 2) return 'Google';
+            count++;
+            return null;
+          });
+      expect(result, equals('Google'));
     });
 
     test('that returns false', () {
-      driver.url = 'http://www.google.com/ncr';
-      var result = waitForValue
-          (() => driver.findElement(const By.name('btnG')).displayed);
+      var count = 0;
+      var result = waitForValue(
+          () {
+            expect(count, lessThanOrEqualTo(2));
+            if (count == 2) {
+              count++;
+              return false;
+            }
+            count++;
+            return null;
+          });
       expect(result, isFalse);
     });
   });
 
   group('custom Matcher', () {
+    WebDriver driver;
+    setUp(() {
+      driver = freshDriver;
+      driver.url = testPagePath;
+    });
+
 
     test('isDisplayed', () {
       var body = driver.findElement(const By.tagName('body'));
@@ -107,8 +113,7 @@ void main() {
     });
 
     test('isNotEnabled', () {
-      var input =
-          driver.findElement(const By.cssSelector('input[type=password]'));
+      var input = driver.findElement(const By.cssSelector('input[type=password]'));
       expect(input, isNotEnabled);
     });
 
@@ -120,7 +125,7 @@ void main() {
   });
 
   group('Select class', () {
-
+    WebDriver driver;
     WebElement selectSimple;
     WebElement selectMulti;
 
@@ -147,7 +152,7 @@ void main() {
       expect(options[3].selected, false);
       expect(options[2], select.firstSelectedOption);
       expect(options[2].text, "Apple");
-      expect(options[2].value, "appleValue");
+      expect(options[2].attributes["value"], "appleValue");
       expect(select.allSelectedOptions, [ options[2] ]);
       expect(select.value, "appleValue");
     });
@@ -164,7 +169,7 @@ void main() {
       expect(options[3].selected, true);
       expect(options[1], select.firstSelectedOption);
       expect(options[1].text, "Green");
-      expect(options[1].value, "greenValue");
+      expect(options[1].attributes["value"], "greenValue");
       expect(select.allSelectedOptions, [ options[1], options[3] ]);
       expect(select.value, "greenValue");
 
@@ -192,7 +197,7 @@ void main() {
       expect(options[2].selected, true);
       expect(options[2], select.firstSelectedOption);
       expect(options[2].text, "Apple");
-      expect(options[2].value, "appleValue");
+      expect(options[2].attributes["value"], "appleValue");
       expect(select.allSelectedOptions, [ options[2] ]);
       expect(select.value, "appleValue");
     });
@@ -206,7 +211,7 @@ void main() {
       expect(options[1].selected, true);
       expect(options[1], select.firstSelectedOption);
       expect(options[1].text, "Green");
-      expect(options[1].value, "greenValue");
+      expect(options[1].attributes["value"], "greenValue");
       expect(select.allSelectedOptions, [ options[1], options[3] ]);
       expect(select.value, "greenValue");
 
@@ -234,7 +239,7 @@ void main() {
       expect(options[2].selected, true);
       expect(options[2], select.firstSelectedOption);
       expect(options[2].text, "Apple");
-      expect(options[2].value, "appleValue");
+      expect(options[2].attributes["value"], "appleValue");
       expect(select.allSelectedOptions, [ options[2] ]);
       expect(select.value, "appleValue");
     });
@@ -248,7 +253,7 @@ void main() {
       expect(options[1].selected, true);
       expect(options[1], select.firstSelectedOption);
       expect(options[1].text, "Green");
-      expect(options[1].value, "greenValue");
+      expect(options[1].attributes["value"], "greenValue");
       expect(select.allSelectedOptions, [ options[1], options[3] ]);
       expect(select.value, "greenValue");
 
@@ -269,3 +274,4 @@ void main() {
     });
   });
 }
+


### PR DESCRIPTION
Update version numbers in pubspec.yaml.

Remove get value from WebElement as the wire protocol command is no longer
available.

Add get value to Select.

Change wait tests to no longer depend on WebDriver.

Change unittest dependency in sync_webdriver to matcher.
