### PR TITLE
Update web_driver.dart

### DIFF
--- a/lib/src/web_driver.dart
+++ b/lib/src/web_driver.dart
@@ -97,9 +97,13 @@ class WebDriver extends SearchContext {
 
   String get pageSource => _get('source');
 
-  void close() => _delete('window');
+  void close() {
+    _delete('window');
+  }
 
-  void quit() => _delete('');
+  void quit() {
+    _delete('');
+  }
 
   Iterable<Window> get windows => _get('window_handles')
       .map((handle) => new Window._(this, handle));


### PR DESCRIPTION
remove => for void functions that call another function with return value. If the called function actually returns something this fails with "Caught type '_LinkedHashMap' is not a subtype of type 'void' of 'function result'." because the void function cannot return what the called function returned.
